### PR TITLE
RMET-2943 ::: Raise iOS deployment target

### DIFF
--- a/ZXingObjC.podspec
+++ b/ZXingObjC.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.xcconfig = { "OTHER_LDFLAGS" => "-ObjC" }
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.8'
 
   s.ios.frameworks = 'AVFoundation', 'CoreGraphics', 'CoreMedia', 'CoreVideo', 'ImageIO', 'QuartzCore'


### PR DESCRIPTION
On the podspec file, raise iOS Deployment Target version to 13.0. This is required for xCode 15 builds as iOS 8.0 frameworks cannot be built anymore.